### PR TITLE
Add support for verifying types using mypy's unit testing 

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,11 @@
+import os
+
+ROOT_DIR = os.path.dirname(__file__)
+# So that it finds the local typings
+os.environ["MYPYPATH"] = os.path.join(ROOT_DIR, "python")
+
+
+# Add mypy's test searcher so we can write test files to verify type checking
+pytest_plugins = ["mypy.test.data"]
+# Set this to the root directory so it finds the `test-data` directory
+os.environ["MYPY_TEST_PREFIX"] = ROOT_DIR

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ classifiers = [
 [project.optional-dependencies]
 dev = ["pre-commit", "black", "mypy", "flake8", "isort"]
 
-test = ["pytest"]
+test = ["pytest", "mypy"]
 
 docs = ["pydata-sphinx-theme", "myst-nb"]
 

--- a/python/tests/test_typing.py
+++ b/python/tests/test_typing.py
@@ -1,3 +1,25 @@
+# Monkeypatch find_test_files so that we can "remove" any files that don't really exist.
+
+# This is required using the `TypeCheckSuite`, because it calls remove on a number of builtin files.
+# we can either make empty versions of them or just monkypatch the function so that it works.
+from mypy.test import helpers
+
+original_find_test_files = helpers.find_test_files
+
+
+class ListRemoveAnything(list):
+    def remove(self, item):
+        pass
+
+
+def new_find_test_files(*args, **kwargs):
+    original_output = original_find_test_files(*args, **kwargs)
+    return ListRemoveAnything(original_output)
+
+
+helpers.find_test_files = new_find_test_files
+
+# Import TypeCheckSuite so it is picked up by pytest.
 from mypy.test.testcheck import TypeCheckSuite
 
 __all__ = ["TypeCheckSuite"]

--- a/python/tests/test_typing.py
+++ b/python/tests/test_typing.py
@@ -20,6 +20,6 @@ def new_find_test_files(*args, **kwargs):
 helpers.find_test_files = new_find_test_files
 
 # Import TypeCheckSuite so it is picked up by pytest.
-from mypy.test.testcheck import TypeCheckSuite
+from mypy.test.testcheck import TypeCheckSuite  # noqa: E402
 
 __all__ = ["TypeCheckSuite"]

--- a/python/tests/test_typing.py
+++ b/python/tests/test_typing.py
@@ -1,0 +1,3 @@
+from mypy.test.testcheck import TypeCheckSuite
+
+__all__ = ["TypeCheckSuite"]

--- a/test-data/unit/check-basic.test
+++ b/test-data/unit/check-basic.test
@@ -1,0 +1,12 @@
+[case bindingsDeclareSort]
+from egg_smol.bindings import EGraph, Var
+
+egraph = EGraph()  # type: EGraph
+egraph.declare_sort(
+    "MyMap",
+    ("Map", [Var("i64"), Var("String")]),
+)
+
+egraph.declare_sort(
+    "MyMap", ["i64", "String"] # E: Argument 2 to "declare_sort" of "EGraph" has incompatible type "List[str]"; expected "Optional[Tuple[str, List[Union[Lit, Var, Call]]]]"
+)


### PR DESCRIPTION
This adds support for verifying that certain code type checks and that certain code doesn't. This allows us to verify that are typings are behaving as they should.

It does this by re-using MyPy's builtin testing framework which is documented here:
https://github.com/python/mypy/blob/master/test-data/unit/README.md

The only other project I found which does this is the SQLAlchemy stubs: https://github.com/angaza/sqlalchemy-stubs/blob/6af1f077745e91d8a4ca624e19cdcf7082aaabdf/test/testsql.py

It ops for another approach however. Instead of reusing the TypeChecker test from MyPy, it builds a new test case that calls out to the MyPy CLI. I choose instead to re-use that test case, so that hopefully it would stay up to date more cleanly.

---

I wanted to get this working for my in progress higher level API design, but also I saw that some other folks were discussing what to do (https://github.com/ipython/traitlets/pull/818#issuecomment-1431485615) since [pytest-mypy-testing](https://github.com/davidfritzsche/pytest-mypy-testing) hasn't been kept up to date recently. So I thought I would give this a go to see if I could use Mypys builtin test framework instead.